### PR TITLE
[bug] fixing nameerror for file_url not defined

### DIFF
--- a/margaritashotgun/repository.py
+++ b/margaritashotgun/repository.py
@@ -381,7 +381,7 @@ class Repository():
             logger.debug("verified {0} against {1}".format(data_url,
                                                            signature_url))
         else:
-            raise RepositorySignatureError(file_url, signature_url)
+            raise RepositorySignatureError(data_url, signature_url)
 
     def verify_file_signature(self, signature_url, file_url, filename):
         """


### PR DESCRIPTION
to @joelferrier / @andrewkrug 

### Changes
* Fix for a NameError that occurs when attempting to raise `RepositorySignatureError` with a variable that does not exist. Appears to be copy pasta from the `verify_file_signature` method.